### PR TITLE
Improve macOS support with build, threading, and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,21 +38,40 @@ You need to [install a Rust build environment](https://www.rust-lang.org/).
 Normally it's fairly straightforward, just follow the instructions on Rust's
 website.
 
+### macOS-specific requirements
+
+On macOS, you'll need:
+- Xcode Command Line Tools (install with `xcode-select --install`)
+- Rust toolchain (install via [rustup](https://rustup.rs/))
+
+### Building
+
 Once that's done you can build an optimized build with:
 
     cargo build --release
 
 That should download all dependencies and output the core library in
-`target/release/`. On Linux that file is named `librustation_ng_retro.so` but
-the name may vary on other platforms.
+`target/release/`. The library file name varies by platform:
+- Linux: `librustation_ng_retro.so`
+- macOS: `librustation_ng_retro.dylib`
+- Windows: `rustation_ng_retro.dll`
 
 ## Run
 
 Once the core is compiled you can load it in your favourite libretro player to
-play your PlayStation games in BIN/CUE format. For instance using retroarch you
-can do:
+play your PlayStation games in BIN/CUE format. For instance using RetroArch:
+
+On Linux:
 
     retroarch -L librustation_ng_retro.so my_game.cue
+
+On macOS:
+
+    retroarch -L librustation_ng_retro.dylib my_game.cue
+
+On Windows:
+
+    retroarch -L rustation_ng_retro.dll my_game.cue
 
 ZIP archives containing bin/cue are also supported. If the archive contains
 several cue files only the first one (in archive order) will be used.

--- a/build.rs
+++ b/build.rs
@@ -14,7 +14,21 @@ fn main() {
     let dest_path = Path::new(&out_dir).join("version.rs");
     let mut f = File::create(&dest_path).expect("Failed to create version.rs file");
 
-    let git = env::var("GIT").unwrap_or_else(|_| "git".into());
+    let git = env::var("GIT").unwrap_or_else(|_| {
+        // On macOS, git might be installed via Homebrew or Xcode Command Line Tools
+        if cfg!(target_os = "macos") {
+            // Try common macOS git locations
+            if Path::new("/usr/bin/git").exists() {
+                "/usr/bin/git".into()
+            } else if Path::new("/opt/homebrew/bin/git").exists() {
+                "/opt/homebrew/bin/git".into()
+            } else {
+                "git".into() // Fall back to PATH
+            }
+        } else {
+            "git".into()
+        }
+    });
 
     let description = Command::new(git).arg("describe").arg("--dirty").output();
 

--- a/src/psx/cd/disc/cache.rs
+++ b/src/psx/cd/disc/cache.rs
@@ -30,9 +30,16 @@ impl Cache {
 
         let thread_reader = reader.clone();
 
+        // macOS has smaller default thread stack sizes, so we need to be more conservative
+        let stack_size = if cfg!(target_os = "macos") {
+            512 * 1024  // 512KB for macOS
+        } else {
+            1024 * 1024 // 1MB for other platforms
+        };
+        
         let builder = thread::Builder::new()
             .name("RSX CD prefetch".to_string())
-            .stack_size(1024 * 1024);
+            .stack_size(stack_size);
 
         let handle = builder
             .spawn(move || {

--- a/src/psx/gpu/rasterizer/mod.rs
+++ b/src/psx/gpu/rasterizer/mod.rs
@@ -166,9 +166,16 @@ pub fn start_from_state(command_buffer: CommandBuffer, mut rasterizer: Rasterize
     let (frame_sender, frame_receiver) = mpsc::channel();
     let (serialization_sender, serialization_receiver) = mpsc::channel();
 
+    // macOS has smaller default thread stack sizes, so we need to be more conservative
+    let stack_size = if cfg!(target_os = "macos") {
+        512 * 1024  // 512KB for macOS
+    } else {
+        1024 * 1024 // 1MB for other platforms
+    };
+    
     let builder = thread::Builder::new()
         .name("RSX GPU".to_string())
-        .stack_size(1024 * 1024);
+        .stack_size(stack_size);
 
     let handle = builder
         .spawn(move || {


### PR DESCRIPTION
## Summary
- Enhance macOS compatibility by updating build script, thread stack sizes, and documentation
- Add macOS-specific instructions and library naming conventions to README
- Adjust git command path resolution in build.rs for macOS environments
- Reduce thread stack sizes on macOS to avoid potential issues with smaller default stacks

## Changes

### Documentation
- Added macOS-specific requirements section to README
- Clarified library file names for Linux, macOS, and Windows
- Provided platform-specific RetroArch usage examples

### Build Script (build.rs)
- Improved detection of git executable path on macOS, checking common locations like `/usr/bin/git` and `/opt/homebrew/bin/git`

### Threading Adjustments
- Reduced thread stack size from 1MB to 512KB on macOS in:
  - `src/psx/cd/disc/cache.rs` for RSX CD prefetch thread
  - `src/psx/gpu/rasterizer/mod.rs` for RSX GPU thread

## Test plan
- Verified build process on macOS with updated git path logic
- Confirmed threads spawn correctly with adjusted stack sizes on macOS
- Tested RetroArch loading instructions on macOS
- Reviewed README formatting and clarity for macOS users

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/93bb418b-c83e-4b7c-aee7-1ddae9bc2bfb