### PR TITLE
Add missing PSX methods and improve debugging support

### DIFF
--- a/src/cd_stub.rs
+++ b/src/cd_stub.rs
@@ -195,5 +195,7 @@ pub struct XaCodingAudio {
 }
 
 pub mod sector {
+    // Re-export sector-related types (currently unused but may be needed later)
+    #[allow(unused_imports)]
     pub use super::{XaSamplingFreq, XaBitsPerSample, XaCodingAudio, Sector};
 }

--- a/src/psx_complete.rs
+++ b/src/psx_complete.rs
@@ -2195,6 +2195,43 @@ impl Psx {
         // R0 is always 0
         self.cpu.regs[0] = 0;
     }
+    
+    pub fn debug_gpu_status(&self) -> u32 {
+        self.gpu.get_status()
+    }
+    
+    pub fn debug_display_info(&self) -> String {
+        format!("Display: {}x{} @ ({}, {}), Draw area: ({},{}) to ({},{})",
+            self.gpu.display_x2 - self.gpu.display_x1,
+            self.gpu.display_y2 - self.gpu.display_y1,
+            self.gpu.display_x,
+            self.gpu.display_y,
+            self.gpu.draw_x1,
+            self.gpu.draw_y1,
+            self.gpu.draw_x2,
+            self.gpu.draw_y2
+        )
+    }
+    
+    pub fn run_next_instruction(&mut self) -> Result<()> {
+        // Simple wrapper to run a single CPU instruction
+        self.cpu.current_pc = self.cpu.pc;
+        
+        // Fetch instruction
+        let instruction = self.load32(self.cpu.pc)?;
+        
+        // Advance PC
+        self.cpu.pc = self.cpu.next_pc;
+        self.cpu.next_pc = self.cpu.pc.wrapping_add(4);
+        
+        // Execute the instruction
+        self.execute_cpu_instruction(instruction);
+        
+        // Tick cycles
+        self.tick(1);
+        
+        Ok(())
+    }
 }
 
 fn mask_region(addr: u32) -> u32 {

--- a/src/wasm_unified.rs
+++ b/src/wasm_unified.rs
@@ -631,10 +631,10 @@ impl PsxEmulator {
         for i in 0..steps {
             let pc_before = self.psx.cpu.pc;
             
-            match self.psx.cpu.run_next_instruction(&mut self.psx) {
-                Ok(cycles) => {
-                    result.push_str(&format!("  Step {}: PC 0x{:08x} -> 0x{:08x} (cycles: {})\n", 
-                                           i, pc_before, self.psx.cpu.pc, cycles.0));
+            match self.psx.run_next_instruction() {
+                Ok(()) => {
+                    result.push_str(&format!("  Step {}: PC 0x{:08x} -> 0x{:08x}\n", 
+                                           i, pc_before, self.psx.cpu.pc));
                 }
                 Err(e) => {
                     result.push_str(&format!("  Step {}: Error at PC 0x{:08x}: {:?}\n", 
@@ -647,20 +647,20 @@ impl PsxEmulator {
         result
     }
     
-    pub fn debug_check_bios(&self) -> String {
+    pub fn debug_check_bios(&mut self) -> String {
         let mut result = String::new();
         
         // Check if BIOS is loaded
-        let bios_start = self.psx.load::<u32>(0xbfc00000);
-        let bios_magic = self.psx.load::<u32>(0xbfc00004);
+        let bios_start = self.psx.load32(0xbfc00000).unwrap_or(0);
+        let bios_magic = self.psx.load32(0xbfc00004).unwrap_or(0);
         
         result.push_str(&format!("BIOS check:\n"));
         result.push_str(&format!("  First word: 0x{:08x}\n", bios_start));
         result.push_str(&format!("  Second word: 0x{:08x}\n", bios_magic));
         
         // Check for common BIOS entry points
-        let reset_vector = self.psx.load::<u32>(0xbfc00000);
-        let exception_vector = self.psx.load::<u32>(0xbfc00180);
+        let reset_vector = self.psx.load32(0xbfc00000).unwrap_or(0);
+        let exception_vector = self.psx.load32(0xbfc00180).unwrap_or(0);
         
         result.push_str(&format!("  Reset vector (0xbfc00000): 0x{:08x}\n", reset_vector));
         result.push_str(&format!("  Exception vector (0xbfc00180): 0x{:08x}\n", exception_vector));


### PR DESCRIPTION
## Summary
- Adds missing methods to the PSX emulator for better debugging and instruction execution
- Enhances GPU status and display information retrieval
- Improves WASM unified interface with updated instruction stepping and BIOS checks
- Minor re-exports and code cleanup in CD stub module

## Changes

### PSX Emulator (`psx_complete.rs`)
- Added `debug_gpu_status` to get current GPU status
- Added `debug_display_info` to provide formatted display and draw area info
- Added `run_next_instruction` to execute a single CPU instruction step with proper PC and cycle handling

### WASM Unified Interface (`wasm_unified.rs`)
- Updated `run_next_instruction` usage to new PSX method
- Simplified debug output for instruction stepping
- Made `debug_check_bios` mutable and improved BIOS loading checks with safe unwraps

### CD Stub (`cd_stub.rs`)
- Re-exported sector-related types with allowance for unused imports for future use

## Test plan
- Verified that single instruction stepping works without errors
- Confirmed GPU status and display info methods return expected values
- Tested BIOS check outputs with valid and invalid BIOS data
- Ensured no regressions in WASM unified stepping and debugging functions

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6b2ed384-245f-4d86-bfec-676a5e6fc9d8