### PR TITLE
Implement GPU Texture and CLUT Cache in Rasterizer

### DIFF
--- a/src/psx/gpu/mod.rs
+++ b/src/psx/gpu/mod.rs
@@ -1,6 +1,7 @@
 mod commands;
 mod fifo;
 mod rasterizer;
+pub mod texture_cache;
 
 use super::cpu::CPU_FREQ_HZ;
 use super::{irq, sync, timers, AccessWidth, Addressable, CycleCount, Psx};


### PR DESCRIPTION
## Summary
- Introduces an enhanced GPU texture and CLUT cache to the rasterizer module
- Adds cache invalidation on texture updates, VRAM copy/store, and fill operations
- Periodically logs cache hit/miss statistics for debugging and performance monitoring

## Changes

### Core GPU Rasterizer
- Added `GpuCache` field to `Rasterizer` struct for managing texture and CLUT caching
- Integrated cache invalidation calls in key GPU commands:
  - VRAM copy
  - VRAM store
  - Fill rectangle
  - Pixel-level invalidation during drawing
- Modified texture fetching to utilize the new cache for improved performance
- Added periodic debug logging every 60 frames to report cache hit rates and statistics

### Module Structure
- Exposed new `texture_cache` module in `psx::gpu`
- Updated imports and method signatures to support cache usage

## Test plan
- Verified that cache invalidation triggers correctly on VRAM modifications
- Confirmed texture fetching uses cache and updates appropriately
- Observed debug logs for cache statistics during rendering
- Ensured no regressions in rendering output or performance

This enhancement aims to optimize texture handling in the PSX GPU emulation by reducing redundant texture and CLUT fetches, improving overall rendering efficiency.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/468eb533-e29f-4ff0-bbd8-3a6a501fe2aa