### PR TITLE
Enhance PadMemCard system with memory card management and reset functionality

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@ mod box_array;
 mod disc_control;
 mod error;
 mod memory_card;
+mod memory_card_manager;
+mod psx_memory_card_integration;
 #[macro_use]
 pub mod libretro;
 #[cfg(feature = "debugger")]


### PR DESCRIPTION
## Summary
- Adds memory card management capabilities to the PadMemCard controller
- Implements reset functionality preserving connected devices
- Supports connecting, disconnecting, and checking memory card connection status

## Changes

### PadMemCard Module
- Introduced `reset` method to reset controller state while preserving connected devices and notifying them of reconnection
- Added methods to manage memory cards:
  - `connect_memory_card(slot, card)`: Connects a memory card device to a specified slot
  - `disconnect_memory_card(slot)`: Disconnects and returns the memory card device from a specified slot
  - `is_memory_card_connected(slot)`: Checks if a memory card is connected in the specified slot
- Updated device imports to include `DeviceInterface` for dynamic device management

### Library Module
- Added new modules `memory_card_manager` and `psx_memory_card_integration` for future memory card system enhancements

## Test plan
- Verify that resetting the PadMemCard controller preserves connected devices and triggers their reconnection handlers
- Test connecting and disconnecting memory cards on both slots
- Confirm that connection status checks return accurate results for connected and disconnected states
- Ensure no panics occur on valid slot indices and panics on invalid slots

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6aa8b0b2-27f3-41a2-93d7-5877188b3903