### PR TITLE
Refactor set_bit method for clarity in bitwise operations

### DIFF
--- a/src/bitwise.rs
+++ b/src/bitwise.rs
@@ -23,8 +23,12 @@ impl Bitwise for u8 {
     }
 
     fn set_bit(&mut self, bitpos: u8, v: bool) {
-        *self &= !(1u8 << bitpos);
-        *self |= (v as u8) << bitpos;
+        let mask = 1u8 << bitpos;
+        if v {
+            *self |= mask;
+        } else {
+            *self &= !mask;
+        }
     }
 }
 
@@ -34,8 +38,12 @@ impl Bitwise for u16 {
     }
 
     fn set_bit(&mut self, bitpos: u8, v: bool) {
-        *self &= !(1u16 << bitpos);
-        *self |= (v as u16) << bitpos;
+        let mask = 1u16 << bitpos;
+        if v {
+            *self |= mask;
+        } else {
+            *self &= !mask;
+        }
     }
 }
 
@@ -45,8 +53,12 @@ impl Bitwise for u32 {
     }
 
     fn set_bit(&mut self, bitpos: u8, v: bool) {
-        *self &= !(1u32 << bitpos);
-        *self |= (v as u32) << bitpos;
+        let mask = 1u32 << bitpos;
+        if v {
+            *self |= mask;
+        } else {
+            *self &= !mask;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Refactored the `set_bit` method implementations for `u8`, `u16`, and `u32` types
- Improved code clarity by replacing combined bitwise operations with explicit conditional logic

## Changes

### Bitwise Trait Implementations
- Replaced the two-step bit clearing and setting with a clearer conditional approach:
  - Calculate the mask for the bit position
  - Use an `if` statement to either set or clear the bit based on the boolean value
- This change enhances readability and maintainability without altering functionality

## Test plan
- Existing tests for bitwise operations should cover these changes
- Verify that setting and clearing bits behaves as expected for all three integer types (`u8`, `u16`, `u32`)
- Confirm no regressions in bitwise manipulation behavior

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/25699205-c9e8-4b91-b39e-6217cd698e13