### PR TITLE
Add CHD disc image support with fallback loading in PSX CD module

### DIFF
--- a/src/psx/cd/mod.rs
+++ b/src/psx/cd/mod.rs
@@ -1,6 +1,7 @@
 //! LLE CD implementation
 
 mod cdc;
+pub mod chd;
 pub mod disc;
 pub mod iso9660;
 


### PR DESCRIPTION
## Summary
- Adds support for loading CHD (Compressed Hunks of Data) disc images in the PSX CD module
- Implements detection of CHD files and attempts to load them
- Provides fallback mechanism to load BIN/CUE images if CHD loading fails
- Introduces simple debug logging for disc operations
- Updates module structure to include new `chd` submodule

## Changes

### Core Functionality
- **CHD Loading**: Added `Disc::from_chd` to load discs from CHD files
- **Format Detection**: Added `Disc::load` to detect CHD format and fallback to other formats
- **Fallback Support**: Implemented `find_fallback_image` to locate BIN/CUE files matching CHD base name
- **Fallback Loader Stub**: Added `load_fallback` method as a placeholder for BIN/CUE loading (not yet implemented)
- **Logging**: Introduced `disc_log!` macro for debug logging in disc operations

### Module Updates
- Added `pub mod chd` in `src/psx/cd/mod.rs` to expose CHD functionality
- Updated imports and error handling in `disc/mod.rs` to support CHD

### Error Handling
- Improved error messages and logging when CHD loading fails or when no BOOT line is found in SYSTEM.CNF

## Test plan
- [ ] Verify CHD files are detected and loaded correctly
- [ ] Confirm fallback BIN/CUE loading is attempted on CHD load failure
- [ ] Check debug logs appear during disc loading in debug builds
- [ ] Validate error handling for corrupted or unsupported disc images
- [ ] Ensure existing ISO9660 and other disc formats continue to load correctly

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/1b24271d-434f-4c32-be29-c079c63dc893