### PR TITLE
Add Vulkan renderer module under feature flag

### DIFF
--- a/src/psx/gpu/mod.rs
+++ b/src/psx/gpu/mod.rs
@@ -5,6 +5,9 @@ mod error_handler;
 mod debug_overlay;
 pub mod texture_cache;
 
+#[cfg(feature = "vulkan-renderer")]
+pub mod vulkan_renderer;
+
 #[cfg(test)]
 mod error_handler_tests;
 


### PR DESCRIPTION
## Summary
- Introduces a new `vulkan_renderer` module in the PSX GPU subsystem
- The module is conditionally compiled only when the `vulkan-renderer` feature is enabled

## Changes

### PSX GPU Module
- Added `vulkan_renderer` as a public submodule guarded by `#[cfg(feature = "vulkan-renderer")]`

## Test plan
- Ensure the project compiles with the `vulkan-renderer` feature enabled
- Verify no compilation errors occur when the feature is disabled
- Further testing of the Vulkan renderer functionality will be done in its own scope

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/01d215ea-7915-4288-ab99-18f6bdbf31a2