### PR TITLE
Add wasm_integration module and test modules to PSX CD disc

### DIFF
--- a/src/psx/cd/disc/mod.rs
+++ b/src/psx/cd/disc/mod.rs
@@ -11,6 +11,14 @@ use std::fmt;
 mod cache;
 pub mod advanced_cache;
 pub mod advanced_cache_wasm;
+pub mod wasm_integration;
+
+#[cfg(test)]
+mod cache_tests;
+#[cfg(test)]
+mod statistics_validation;
+#[cfg(test)]
+mod regression_tests;
 
 /// PlayStation disc.
 ///


### PR DESCRIPTION
## Summary
- Introduces a new `wasm_integration` module in the PSX CD disc component
- Adds multiple test modules: `cache_tests`, `statistics_validation`, and `regression_tests` for improved test coverage

## Changes

### Module Additions
- **wasm_integration**: New module added under `src/psx/cd/disc` for WebAssembly related integration

### Testing Enhancements
- Added `cache_tests` module for cache-related unit tests
- Added `statistics_validation` module for validating statistical data
- Added `regression_tests` module to cover regression scenarios

## Test plan
- All new test modules are conditionally compiled with `#[cfg(test)]` and should be run with `cargo test`
- Verify that the new wasm integration module compiles and integrates correctly with existing codebase

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e4b124ae-84bf-4063-94f7-1c4e9c40d57f