### PR TITLE
Add frame pacing and VRR support to GPU module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ mod bitwise;
 mod box_array;
 mod disc_control;
 mod error;
+pub mod frame_pacing;
 mod memory_card;
 mod memory_card_manager;
 mod psx_memory_card_integration;


### PR DESCRIPTION
## Summary
- Introduces frame pacing and variable refresh rate (VRR) support in the GPU module
- Adds a new `frame_pacing` module and integrates it into the GPU struct
- Enables detection of display capabilities and configuration of frame pacing features

## Changes

### Core GPU Enhancements
- Added `frame_pacing` module to the library
- Integrated `FramePacer` into the `Gpu` struct for managing frame pacing and VRR
- Initialized frame pacer during GPU construction with display capability detection and PAL mode setting

### New GPU Methods for Frame Pacing
- `set_display_mode`: Configure the display mode for frame pacing
- `set_black_frame_insertion`: Enable or disable black frame insertion
- `set_motion_interpolation`: Enable or disable motion interpolation for high refresh rate displays
- `set_beam_racing_offset`: Adjust beam racing offset for CRT-like latency
- `get_frame_pacing_stats`: Retrieve statistics related to frame pacing
- `get_display_capabilities`: Detect and return current display capabilities
- `get_speed_adjustment`: Get current speed adjustment for host synchronization
- `get_audio_resample_ratio`: Get audio resample ratio for synchronization

## Test plan
- Verify GPU initialization includes frame pacer setup
- Test setting and retrieving frame pacing modes and options
- Confirm display capability detection works correctly
- Validate retrieval of frame pacing statistics and sync parameters

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9028294a-1ec2-4b02-9bdf-d1400943fee2