### PR TITLE
Add GGPO rollback netplay dependencies and update Cargo features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rusqlite = { version = "0.30", features = ["bundled", "serde_json"], optional = 
 chrono = { version = "0.4", features = ["serde"], optional = true }
 uuid = { version = "1.6", features = ["v4", "serde"], optional = true }
 reqwest = { version = "0.11", features = ["json"], optional = true }
-tokio = { version = "1", features = ["rt", "macros"], optional = true }
+tokio = { version = "1", features = ["rt", "macros", "net", "sync", "time"], optional = true }
 
 # Shader compilation dependencies
 crossbeam-channel = "0.5"
@@ -37,6 +37,20 @@ sha2 = "0.10"
 hex = "0.4"
 bincode = "1.3"
 num_cpus = "1.16"
+
+# GGPO Netplay dependencies
+flate2 = "1.0"
+crc32fast = "1.3"
+ring = "0.17"
+quinn = { version = "0.10", optional = true }
+webrtc = { version = "0.9", optional = true }
+igd = { version = "0.12", optional = true }
+stun_codec = { version = "0.3", optional = true }
+parking_lot = "0.12"
+dashmap = "5.5"
+bytes = "1.5"
+futures = "0.3"
+async-trait = "0.1"
 
 # Vulkan dependencies
 ash = { version = "0.37", optional = true }
@@ -72,6 +86,8 @@ features = [
 default = []
 compatibility-db = ["rusqlite", "chrono", "uuid"]
 online-sync = ["reqwest", "tokio", "compatibility-db"]
+netplay = ["tokio", "quinn", "webrtc", "igd"]
+fightcade = ["netplay"]
 
 [profile.release]
 opt-level = "s"


### PR DESCRIPTION
## Summary
- Adds necessary dependencies for GGPO rollback netplay implementation
- Updates Cargo.toml to include new crates and features for netplay support
- Expands Tokio features to support networking, synchronization, and timing
- Introduces new feature flags `netplay` and `fightcade` for modular builds

## Changes

### Dependency Updates
- Added GGPO netplay related crates:
  - `flate2`, `crc32fast`, `ring` for compression, checksums, and cryptography
  - `quinn`, `webrtc`, `igd`, `stun_codec` for networking and NAT traversal
  - `parking_lot`, `dashmap`, `bytes`, `futures`, `async-trait` for concurrency and async support

### Cargo Features
- Expanded `tokio` features to include `net`, `sync`, and `time` for enhanced async runtime capabilities
- Added new feature groups:
  - `netplay` includes `tokio`, `quinn`, `webrtc`, and `igd`
  - `fightcade` depends on `netplay`

## Test plan
- Verify that the project builds successfully with the new dependencies and features enabled
- Ensure no regressions in existing functionality
- Prepare for subsequent implementation of GGPO rollback netplay logic

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/750daa15-86aa-445e-baff-90f77ff03338