### PR TITLE
Add CRT shader modules to PSX GPU

### DIFF
--- a/src/psx/gpu/mod.rs
+++ b/src/psx/gpu/mod.rs
@@ -8,6 +8,8 @@ mod rendering_pipeline;
 mod enhanced_rasterizer;
 pub mod shader_cache;
 pub mod shader_manager;
+pub mod crt_shaders;
+pub mod crt_shader_pipeline;
 
 #[cfg(feature = "vulkan")]
 pub mod vulkan_shader;


### PR DESCRIPTION
## Summary
- Introduces new CRT shader modules to the PSX GPU subsystem
- Adds `crt_shaders` and `crt_shader_pipeline` modules for enhanced shader effects

## Changes

### PSX GPU Module
- **crt_shaders**: New module for CRT shader implementations
- **crt_shader_pipeline**: New module managing the CRT shader rendering pipeline
- Updated `src/psx/gpu/mod.rs` to include these new modules

## Test plan
- [ ] Verify integration of CRT shaders with existing GPU rendering pipeline
- [ ] Test rendering output with CRT shader effects enabled
- [ ] Ensure no regressions in other GPU functionalities

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/bc4b05b9-7320-4321-9c3d-887ea7d42158