### PR TITLE
Add frame interpolation module to PSX GPU

### DIFF
--- a/src/psx/gpu/mod.rs
+++ b/src/psx/gpu/mod.rs
@@ -8,6 +8,7 @@ mod rendering_pipeline;
 mod enhanced_rasterizer;
 pub mod shader_cache;
 pub mod shader_manager;
+pub mod frame_interpolation;
 
 #[cfg(feature = "vulkan")]
 pub mod vulkan_shader;
@@ -33,6 +34,7 @@ pub use rendering_pipeline::{RenderingMode, RenderingPipeline};
 use error_handler::{GpuCommandError, ErrorRecoveryAction, report_gpu_error, check_vram_bounds, check_clut_bounds};
 use debug_overlay::{DebugOverlay, DebugOverlayConfig};
 use shader_manager::{ShaderManager, DrawState, ShaderHandle};
+use frame_interpolation::{FrameInterpolator, InterpolationConfig, InterpolationMode};
 
 // Re-export ColorDepth for use in rasterizer
 use self::ColorDepth;


### PR DESCRIPTION
## Summary
- Introduces a new `frame_interpolation` module in the PSX GPU subsystem
- Exposes `FrameInterpolator`, `InterpolationConfig`, and `InterpolationMode` for frame interpolation functionality
- Updates GPU module imports and exports to include the new frame interpolation components

## Changes

### PSX GPU Module
- Added `frame_interpolation` as a public submodule
- Imported `FrameInterpolator`, `InterpolationConfig`, and `InterpolationMode` from the new module for use within the GPU context

## Test plan
- Ensure existing GPU functionality remains unaffected
- Validate that the new frame interpolation components are accessible and can be integrated in subsequent development
- Run existing GPU tests to confirm no regressions

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/61fbaec0-edc7-4d47-bb51-dfc528bf0dc4