### PR TITLE
Add regression testing binaries and dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,18 @@ edition = "2021"
 crate-type = ["cdylib"]
 path = "src/wasm_unified.rs"
 
+[[bin]]
+name = "replay-harness"
+path = "src/bin/replay-harness.rs"
+
+[[bin]]
+name = "visual-test"
+path = "src/bin/visual-test.rs"
+
+[[bin]]
+name = "save-state-test"
+path = "src/bin/save-state-test.rs"
+
 [features]
 default = []
 pgxp = []
@@ -37,6 +49,10 @@ sha2 = "0.10"
 hex = "0.4"
 bincode = "1.3"
 num_cpus = "1.16"
+
+# Testing dependencies
+toml = "0.8"
+backtrace = "0.3"
 
 # Vulkan dependencies
 ash = { version = "0.37", optional = true }


### PR DESCRIPTION
## Summary
- Introduces three new binaries for regression testing: `replay-harness`, `visual-test`, and `save-state-test`
- Adds testing dependencies `toml` and `backtrace` to support the new testing infrastructure

## Changes

### Cargo.toml
- Added new binary targets for regression testing tools:
  - `replay-harness` at `src/bin/replay-harness.rs`
  - `visual-test` at `src/bin/visual-test.rs`
  - `save-state-test` at `src/bin/save-state-test.rs`
- Included testing dependencies:
  - `toml` version `0.8` for configuration parsing
  - `backtrace` version `0.3` for improved error diagnostics during tests

## Test plan
- Verify that the new binaries compile successfully
- Ensure the added dependencies are correctly resolved and linked
- Run the regression testing binaries to confirm they execute without errors

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6a50c3c5-5e4b-485b-8ebb-484b6c7ffc10