### PR TITLE
Add full peripheral support modules and exports

### DIFF
--- a/src/psx/pad_memcard/devices/mod.rs
+++ b/src/psx/pad_memcard/devices/mod.rs
@@ -12,9 +12,23 @@ pub mod rumble_effects;
 pub mod enhanced_mouse;
 pub mod enhanced_guncon;
 pub mod enhanced_multitap;
+pub mod jogcon;
+pub mod flightstick;
+pub mod link_cable;
+pub mod usb_adapter;
+pub mod controller_profiles;
+pub mod peripheral_factory;
 
 // Re-export common types
 pub use peripheral_trait::{Peripheral as PeripheralTrait, Response};
+pub use jogcon::JogCon;
+pub use flightstick::FlightStick;
+pub use link_cable::LinkCable;
+pub use usb_adapter::UsbAdapter;
+pub use controller_profiles::ProfileManager;
+pub use peripheral_factory::{PeripheralFactory, PeripheralType};
+pub use link_cable::NetworkAdapter;
+pub use usb_adapter::AdapterType;
 
 use super::DsrState;
 use gamepad::{Button, ButtonState};


### PR DESCRIPTION
## Summary
- Introduces full peripheral support in the PSX pad_memcard devices module
- Adds new peripheral modules: JogCon, FlightStick, LinkCable, USB Adapter, Controller Profiles, and Peripheral Factory
- Re-exports new peripheral types and related enums for external use

## Changes

### Peripheral Modules
- Added `jogcon` module for JogCon device support
- Added `flightstick` module for FlightStick device support
- Added `link_cable` module for Link Cable and Network Adapter support
- Added `usb_adapter` module for USB Adapter and AdapterType support
- Added `controller_profiles` module for managing controller profiles
- Added `peripheral_factory` module for creating peripherals and managing peripheral types

### Exports
- Re-exported new peripheral structs and enums:
  - `JogCon`, `FlightStick`, `LinkCable`, `UsbAdapter`
  - `ProfileManager` from controller_profiles
  - `PeripheralFactory`, `PeripheralType` from peripheral_factory
  - `NetworkAdapter` from link_cable
  - `AdapterType` from usb_adapter

## Test plan
- Ensure all new peripheral modules compile without errors
- Verify that the new peripherals can be instantiated and integrated into the existing system
- Add unit tests for new peripheral functionality in their respective modules
- Confirm that re-exports are accessible and correctly typed from the devices module

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/83009fda-c8ef-4c47-a36d-4397f970a040