### PR TITLE
Add Ghidra integration to debugger module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/wasm_unified.rs"
 default = []
 pgxp = []
 debugger = []
+ghidra = ["debugger", "chrono", "serde_json"]
 compatibility-db = ["rusqlite", "chrono", "uuid"]
 online-sync = ["reqwest", "tokio", "compatibility-db"]
 cloud-sync = ["reqwest", "tokio", "async-trait", "ring", "uuid", "chrono"]


### PR DESCRIPTION
## Summary
- Introduces Ghidra integration into the debugger module
- Adds support for initializing, exporting, importing, and handling Ghidra projects and databases
- Exposes breakpoint and watchpoint management methods publicly for external use
- Updates Cargo.toml to include Ghidra feature dependencies

## Changes

### Debugger Module
- Added `GhidraIntegration` and `GhidraConfig` usage
- Added optional `ghidra` field to `Debugger` struct
- Implemented methods:
  - `init_ghidra` to initialize Ghidra integration
  - `export_to_ghidra` to export PSX state to a Ghidra project
  - `import_ghidra_database` to import a Ghidra database
  - `handle_ghidra` to manage Ghidra connections and synchronize breakpoints
- Made breakpoint and watchpoint add/delete methods public

### Cargo.toml
- Added `ghidra` feature with dependencies on `debugger`, `chrono`, and `serde_json`
- Marked `ring` dependency as optional

## Test plan
- Verify Ghidra integration initializes correctly
- Test exporting and importing Ghidra projects and databases
- Confirm breakpoint synchronization with Ghidra
- Validate public breakpoint/watchpoint management methods
- Ensure no regressions in existing debugger functionality

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/1c3e9e5b-65af-43f0-b52d-ef709cb03199