### PR TITLE
Add memory forensics support with RAM, BIOS, and scratchpad access

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ discord-rpc = ["discord-rich-presence", "tokio"]
 game-library = ["rusqlite", "chrono", "uuid", "regex"]
 game-library-online = ["game-library", "reqwest", "tokio", "async-trait"]
 streaming = ["ffmpeg-next", "opus", "x264", "websocket", "v4l", "cpal"]
+memory-forensics = ["mlua", "keystone"]
 
 [dependencies]
 wasm-bindgen = "0.2"
@@ -101,6 +102,14 @@ spirv-reflect = { version = "0.2", optional = true }
 
 # OpenGL dependencies
 gl = { version = "0.14", optional = true }
+
+# Memory forensics dependencies
+xml-rs = "0.8"
+pest = "2.7"
+pest_derive = "2.7"
+mlua = { version = "0.9", features = ["lua54", "vendored"], optional = true }
+capstone = "0.11"
+keystone = { version = "0.9", optional = true }
 
 # Dear ImGui dependencies
 imgui = "0.11"

--- a/src/error.rs
+++ b/src/error.rs
@@ -86,4 +86,6 @@ pub enum PsxError {
     NetworkError,
     #[error("Web environment error")]
     WebEnvironmentError,
+    #[error("Memory forensics error: {0}")]
+    ForensicsError(String),
 }

--- a/src/psx/mod.rs
+++ b/src/psx/mod.rs
@@ -46,6 +46,8 @@ pub mod display_sync;
 pub mod retroachievements;
 pub mod security;
 pub mod orchestration;
+#[cfg(feature = "memory-forensics")]
+pub mod memory_forensics;
 
 // ARM-specific optimizations
 #[cfg(target_arch = "aarch64")]
@@ -1255,6 +1257,18 @@ impl ScratchPad {
 
         for i in 0..T::width() as usize {
             self.data[offset + i] = (val >> (i * 8)) as u8;
+        }
+    }
+
+    /// Get read-only access to scratchpad data (for forensics)
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    /// Set scratchpad data (for save states)
+    pub fn set_data(&mut self, data: &[u8]) {
+        if data.len() == SCRATCH_PAD_SIZE {
+            self.data.copy_from_slice(data);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Introduces memory forensics tools feature flag
- Adds read-only and writable accessors for RAM, BIOS, and scratchpad memory
- Extends error handling with a dedicated forensics error variant
- Updates dependencies to include memory forensics related crates (mlua, keystone, pest, capstone, xml-rs)

## Changes

### Core Functionality
- **Memory Accessors**: Added methods in `XMemory` to get and set RAM and BIOS contents for forensics and save states
- **ScratchPad Enhancements**: Added methods to get and set scratchpad data for forensic analysis and save states
- **Error Handling**: Added `ForensicsError` variant to `PsxError` enum for specialized error reporting

### Module Structure
- Added `memory_forensics` module under `psx` gated by the `memory-forensics` feature flag

### Dependency Updates
- Added new dependencies in `Cargo.toml` for memory forensics including `mlua`, `keystone`, `pest`, `capstone`, and `xml-rs`

## Test plan
- [ ] Verify memory accessors correctly read and write RAM, BIOS, and scratchpad data
- [ ] Test error handling for memory forensics operations
- [ ] Ensure feature flag gating works correctly
- [ ] Validate integration of new dependencies and successful compilation with feature enabled

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6eaf1935-59dc-417b-89d9-a4b8ba863d2a