### PR TITLE
Add cloud gaming infrastructure feature flag and dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ discord-rpc = ["discord-rich-presence", "tokio", "serde_json"]
 game-library = ["rusqlite", "chrono", "uuid", "regex"]
 game-library-online = ["game-library", "reqwest", "tokio", "async-trait"]
 streaming = ["ffmpeg-next", "opus", "x264", "librtmp", "websocket", "v4l", "cpal"]
+cloud-gaming = ["webrtc", "tokio", "futures", "bytes", "rand", "stun_codec", "turn", "ice"]
 
 [dependencies]
 wasm-bindgen = "0.2"
@@ -135,6 +136,11 @@ librtmp = { version = "0.1", optional = true }
 websocket = { version = "0.26", optional = true }
 v4l = { version = "0.14", optional = true }
 cpal = { version = "0.15", optional = true }
+
+# Cloud Gaming dependencies
+turn = { version = "0.6", optional = true }
+ice = { version = "0.10", optional = true }
+rand = { version = "0.8", optional = true }
 
 [dev-dependencies]
 flexbuffers = "2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,8 @@ pub mod streaming;
 pub mod game_library;
 #[cfg(feature = "cloud-sync")]
 pub mod cloud_sync;
+#[cfg(feature = "cloud-gaming")]
+pub mod cloud_gaming;
 #[macro_use]
 pub mod libretro;
 #[cfg(feature = "debugger")]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -33,3 +33,7 @@ mod discord_rpc_tests;
 
 #[cfg(test)]
 mod rewind_tests;
+
+#[cfg(test)]
+#[cfg(feature = "cloud-gaming")]
+mod cloud_gaming_tests;


### PR DESCRIPTION
## Summary
- Introduces a new feature flag `cloud-gaming` for cloud gaming infrastructure
- Adds necessary dependencies for cloud gaming including `webrtc`, `tokio`, `futures`, `bytes`, `rand`, `stun_codec`, `turn`, and `ice`
- Updates Cargo.toml to include these dependencies under the `cloud-gaming` feature
- Modifies `lib.rs` to conditionally compile the `cloud_gaming` module when the feature is enabled
- Adds test module scaffolding for cloud gaming under conditional compilation

## Changes

### Dependency Management
- Added `cloud-gaming` feature with relevant dependencies in Cargo.toml
- Marked some dependencies as optional to support feature gating

### Codebase
- Enabled `cloud_gaming` module in `lib.rs` with feature flag `cloud-gaming`
- Added conditional test module for cloud gaming in `src/tests/mod.rs`

## Test plan
- Ensure the project compiles with the `cloud-gaming` feature enabled
- Run tests with `cloud-gaming` feature to verify the new test module is included
- Validate no impact on existing features when `cloud-gaming` is disabled

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/eae35dad-6664-4ebc-a809-3ceabd3e3dac