### PR TITLE
Refactor test module imports and add unified test module in wasm_unified.rs

### DIFF
--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -19,21 +19,7 @@ mod input_validation_tests;
 mod memory_safety_tests;
 
 #[cfg(test)]
-mod run_ahead_tests;
-
-#[cfg(test)]
 mod integration_tests;
 
 #[cfg(test)]
 mod wasm_minimal_tests;
-
-#[cfg(test)]
-#[cfg(feature = "discord-rpc")]
-mod discord_rpc_tests;
-
-#[cfg(test)]
-mod rewind_tests;
-
-#[cfg(test)]
-#[cfg(feature = "cloud-gaming")]
-mod cloud_gaming_tests;

--- a/src/wasm_unified.rs
+++ b/src/wasm_unified.rs
@@ -31,6 +31,10 @@ mod bitwise;
 #[path = "box_array.rs"]
 mod box_array;
 
+// Include test modules when testing
+#[cfg(test)]
+mod tests;
+
 // Performance dashboard module (commented out - module not yet implemented)
 // pub mod performance_dashboard;
 


### PR DESCRIPTION
## Summary
- Removed several test module imports from `src/tests/mod.rs` to clean up unused or redundant test modules
- Added a unified test module import in `src/wasm_unified.rs` for better test organization

## Changes

### Test Module Cleanup
- Deleted imports for `run_ahead_tests`, `discord_rpc_tests`, `rewind_tests`, and `cloud_gaming_tests` from `src/tests/mod.rs`
- This reduces clutter and removes potentially unused or deprecated test modules

### Unified Test Module Addition
- Added `#[cfg(test)] mod tests;` in `src/wasm_unified.rs` to include test modules when running tests
- Helps centralize test code related to wasm_unified functionality

## Test plan
- Run existing test suite to ensure no regressions or missing tests
- Confirm that tests in `wasm_unified.rs` are properly included and executed
- Verify that removed test modules are not required or referenced elsewhere

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9090994f-0ced-4051-ba48-e8c1551e0f2c